### PR TITLE
fix: Fixed code128 value 102 pattern

### DIFF
--- a/lib/src/barcode_painter.dart
+++ b/lib/src/barcode_painter.dart
@@ -651,7 +651,7 @@ class BarCodePainter extends CustomPainter {
       0x5de,
       0x5ee,
       0x75e,
-      0x7a2,
+      0x7ae,
       0x684,
       0x690,
       0x69c


### PR DESCRIPTION
This branch contains fix for the following issue

Pattern for value 102 of Code128 is wrong #20
